### PR TITLE
Add default value to $data in Cart-Button block

### DIFF
--- a/Afterpay/Afterpay/Block/Cart/Button.php
+++ b/Afterpay/Afterpay/Block/Cart/Button.php
@@ -34,7 +34,7 @@ class Button extends Template
         AfterpayConfig $afterpayConfig,
         CheckoutSession $checkoutSession,
         Currency $currency,
-        array $data
+        array $data = []
     ) {
         $this->afterpayConfig = $afterpayConfig;
         $this->checkoutSession = $checkoutSession;


### PR DESCRIPTION
If you try and DI this block (not through the layout system) into one of
your classes then it will fail because M2 will not pass anything to
$data if it hasn't been told you explicitly.