### PR TITLE
Fix for warning message during cron executing

### DIFF
--- a/Afterpay/Afterpay/Model/Cron/Limit.php
+++ b/Afterpay/Afterpay/Model/Cron/Limit.php
@@ -104,7 +104,7 @@ class Limit
 
             // understand the response from the API
             foreach ($response as $result) {
-                if ($result['type'] === \Afterpay\Afterpay\Model\Payovertime::AFTERPAY_PAYMENT_TYPE_CODE_V1) {
+                if (!empty($result['type']) && $result['type'] === \Afterpay\Afterpay\Model\Payovertime::AFTERPAY_PAYMENT_TYPE_CODE_V1) {
                     $minTotal = isset($result['minimumAmount']['amount']) ? $result['minimumAmount']['amount'] : "0";
                     $maxTotal = isset($result['maximumAmount']['amount']) ? $result['maximumAmount']['amount'] : "0";
                 }


### PR DESCRIPTION
Fix for warning
2018-11-11 19:09:01] report.CRITICAL: Warning: Illegal string offset 'type' in app/code/Afterpay/Afterpay/Model/Cron/Limit.php on line 107
