### PR TITLE
Avoid fatal js errors in case the price element is not detected

### DIFF
--- a/Afterpay/Afterpay/view/frontend/web/js/view/product/afterpay-products.js
+++ b/Afterpay/Afterpay/view/frontend/web/js/view/product/afterpay-products.js
@@ -42,25 +42,27 @@ require(
 
 			var price = price_raw.text().match(/[\d\.]+/g);
 
-			if (price[1]) {
-				product_variant_price = price[0]+price[1];
-			} else {
-				product_variant_price = price[0];
-			}
+			if (price) {
+				if (price[1]) {
+					product_variant_price = price[0]+price[1];
+				} else {
+					product_variant_price = price[0];
+				}
 
-			var instalment_price = parseFloat(Math.round(product_variant_price / 4 * 100) / 100);
+				var instalment_price = parseFloat(Math.round(product_variant_price / 4 * 100) / 100);
 
-			//pass the price format object - fix for the group product format
+				//pass the price format object - fix for the group product format
 
-			var format = {decimalSymbol: '.',pattern:'$%s'};
-			var formatted_instalment_price = priceUtils.formatPrice(instalment_price,format);
+				var format = {decimalSymbol: '.',pattern:'$%s'};
+				var formatted_instalment_price = priceUtils.formatPrice(instalment_price,format);
 
-			$('.afterpay-installments.afterpay-installments-amount .afterpay_instalment_price').text(formatted_instalment_price);
+				$('.afterpay-installments.afterpay-installments-amount .afterpay_instalment_price').text(formatted_instalment_price);
 
-			if (parseFloat(product_variant_price) >= parseFloat(min_limit) && parseFloat(product_variant_price) <= parseFloat(max_limit)) {
-				afterpay_instalment_element.show();
-			} else {
-				afterpay_instalment_element.hide();
+				if (parseFloat(product_variant_price) >= parseFloat(min_limit) && parseFloat(product_variant_price) <= parseFloat(max_limit)) {
+					afterpay_instalment_element.show();
+				} else {
+					afterpay_instalment_element.hide();
+				}
 			}
 		}
 	}


### PR DESCRIPTION
My Magento2 product pages partly broke with the afterpay 3.0.5 upgrade, because the price selector changed.

Despite the probably valid question why I do not have a `data-price=type=finalPrice` attribute on my final price, such a situation should not end in an "uncaught TypeError", blocking further JS from being executed:

```
clearpay-products.js:45 Uncaught TypeError: Cannot read property '1' of null
    at setInstalment (clearpay-products.js:45)
    at HTMLDocument.<anonymous> (clearpay-products.js:19)
    at fire (jquery.js:3232)
    at Object.add [as done] (jquery.js:3291)
    at jQuery.fn.init.jQuery.fn.ready (jquery.js:3542)
    at clearpay-products.js:18
    at Object.execCb (require.js:1650)
    at Module.check (require.js:866)
    at Module.<anonymous> (require.js:1113)
    at require.js:132
```

My suggestion is, to at least check if `price` is an object before continuing to use it. This is the content of my pull request. Please feel free to improve!