### PR TITLE
Update requirejs map configuration

### DIFF
--- a/view/frontend/requirejs-config.js
+++ b/view/frontend/requirejs-config.js
@@ -8,7 +8,8 @@ var config = {
     map: {
         '*': {
             afterpay:    'https://www-dev.secure-afterpay.com.au/afterpay.js', // @todo change to use dynamic js window.checkoutConfig.payment.afterpay.afterpayJs
-            transparent: 'Magento_Payment/transparent'
+            transparent: 'Magento_Payment/js/transparent',
+            'Magento_Payment/transparent': 'Magento_Payment/js/transparent'
         }
     }
 };


### PR DESCRIPTION
The current requirejs-config.js map configuration references Magento_Payment/transparent, but the path changed to Magento_Payment/js/transparent in later versions of Magento 2.2.x. This causes transparent.js to return a 404 error on the checkout/#payments page when using 2.3.x and more recent version of 2.2.x. The map configuration needs to be updated to include both the old path and new path for compatibility with both 2.2.x and 2.3.x.