### PR TITLE
Fix deprecation warning for PHP 7.4

### DIFF
--- a/Model/Adapter/V2/AfterpayOrderTokenV2.php
+++ b/Model/Adapter/V2/AfterpayOrderTokenV2.php
@@ -177,7 +177,7 @@ class AfterpayOrderTokenV2
         } 
 		
         if (count($errors)) {
-            throw new \Magento\Framework\Exception\LocalizedException(__(implode($errors, ' ; ')));
+            throw new \Magento\Framework\Exception\LocalizedException(__(implode(' ; ', $errors)));
         } else {
             return true;
         }


### PR DESCRIPTION
Swapped param 1 and param 2.

Only occurs when Afterpay attempts error on invalid inputs by customer