### PR TITLE
Fix for PHP warning on config save

### DIFF
--- a/Model/Config/Save/Plugin.php
+++ b/Model/Config/Save/Plugin.php
@@ -62,7 +62,7 @@ class Plugin
 
             try {
                 $configRequest = $subject->getGroups();
-                $this->requested = array_key_exists(\Afterpay\Afterpay\Model\Payovertime::METHOD_CODE, $configRequest);
+                $this->requested = is_array($configRequest) && array_key_exists(\Afterpay\Afterpay\Model\Payovertime::METHOD_CODE, $configRequest);
 				
 				if ($this->requested) {
 					$config_array=$configRequest[\Afterpay\Afterpay\Model\Payovertime::METHOD_CODE]['groups'][\Afterpay\Afterpay\Model\Payovertime::METHOD_CODE . '_basic']['fields'][\Afterpay\Afterpay\Model\Config\Payovertime::ACTIVE];


### PR DESCRIPTION
Fix for Warning: array_key_exists() expects parameter 2 to be array, null given