### PR TITLE
Update composer.json require with PHP7.4.0 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "description": "Magento 2 Afterpay Payment Module",
     "version": "4.0.0",
     "require": {
-        "php": "~7.1.3||~7.2.0||~7.3.0",
+        "php": "~7.1.3||~7.2.0||~7.3.0||~7.4.0",
         "magento/framework": "^102.0",
         "magento/module-checkout": "100.3.*",
         "magento/module-payment": "100.3.*",


### PR DESCRIPTION
In your documentation you recommend version 4.0.0 for Magento 2.3.X release line and version 5.0.0 for Magento 2.4.X release line. This creates a problem as Magento 2.3.7+ includes support for PHP7.4. When adding "afterpay-global/module-afterpay": "4.0.0" via composer the following error occurs "afterpay-global/module-afterpay 4.0.0 requires php ~7.1.3||~7.2.0||~7.3.0 -> your php version (7.4.19) does not satisfy that requirement.". Unless there is PHP7.4 compatibility issue within this 4.0.0 version I would suggest bumping the PHP requires up to 7.4 in the composer.json to allow for this composer install scenario.