### PR TITLE
Afterpay payment method <label> not clickable

### DIFF
--- a/view/frontend/web/template/payment/afterpay.html
+++ b/view/frontend/web/template/payment/afterpay.html
@@ -1,6 +1,7 @@
-<div class="payment-method" id="afterpay" data-bind="css: {'_active': (getCode() == isChecked())}">
+<div class="payment-method afterpay" data-bind="css: {'_active': (getCode() == isChecked())}">
     <div class="payment-method-title field choice">
         <input type="radio"
+               id="afterpay"
                name="payment[method]"
                class="radio"
                data-bind="attr: {'id': getCode()}, value: getCode(), checked: isChecked, click: selectPaymentMethod, visible: isRadioButtonVisible()"/>


### PR DESCRIPTION
Found an issue where the Afterpay payment method's label element is not clickable to select the methods radio button and set the payment method as _active. This is due to the id="afterpay" being added to "payment-method" DIV element instead of the input type="radio" element. For form elements to be selectable via the associated label element the ID of the input must match the labels "for" attribute for example label for="afterpay". This is quite a large usability issue as customers will more often than not click or touch the Afterpay logo within the label element to select the payment method rather than selecting the radio button itself.

I also note the styling in the afterpay-checkout.less file also relies on this parent ID for styling. This would have to be updated to use a class="afterpay" instead so the ID can be moved to the input.

This would also affect v5.0.0 version of the Afterpay module as well.