### PR TITLE
Magento 2.4.6 & PHP 8.2 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "description": "Magento 2 Afterpay Payment Module",
     "version": "5.0.5",
     "require": {
-        "php": "~7.4.0||~8.1.0",
+        "php": "~8.1.0||~8.2.0",
         "magento/framework": "^103.0",
         "magento/module-checkout": "100.4.*",
         "magento/module-payment": "100.4.*",


### PR DESCRIPTION
Currently cannot install AfterPay 5.0.5 module via composer when upgrading to Magento 2.4.6 & PHP 8.2. Lack of compatibility prevents anyone using AfterPay from upgrading to the latest Magento & PHP versions. Module must be patched / upgraded to support latest versions.

`  Problem 1
    - Root composer.json requires afterpay-global/module-afterpay 5.0.5 -> satisfiable by afterpay-global/module-afterpay[5.0.5].
    - afterpay-global/module-afterpay 5.0.5 requires php ~7.4.0||~8.1.0 -> your php version (8.2.4) does not satisfy that requirement.`