### PR TITLE
Update taxAmount in checkout data builder

### DIFF
--- a/Gateway/Request/Checkout/CheckoutDataBuilder.php
+++ b/Gateway/Request/Checkout/CheckoutDataBuilder.php
@@ -72,7 +72,7 @@ class CheckoutDataBuilder implements \Magento\Payment\Gateway\Request\BuilderInt
             'merchantReference' => $quote->getReservedOrderId(),
             'taxAmount' => [
                 'amount' => $this->formatPrice(
-                    $billingTaxAmount ?: $shippingTaxAmount
+                    (float) $billingTaxAmount ?: $shippingTaxAmount
                 ),
                 'currency' => $isCBTCurrencyAvailable ? $quote->getQuoteCurrencyCode() : $quote->getBaseCurrencyCode()
             ],


### PR DESCRIPTION
When I see it, the problem is that $billingTaxAmount can be set to "0.00", which will evaluate as true. As a result, the condition fails here: **$billingTaxAmount ?: $shippingTaxAmount.**

So, I have made a fix to handle this. Please review and let me know.