### PR TITLE
Remove save function from checkout management file

### DIFF
--- a/Model/CheckoutManagement/CheckoutManagement.php
+++ b/Model/CheckoutManagement/CheckoutManagement.php
@@ -38,7 +38,6 @@ class CheckoutManagement implements \Afterpay\Afterpay\Api\CheckoutManagementInt
         /** @var \Magento\Quote\Model\Quote $quote */
         $quote = $this->getActiveQuoteByCartOrQuoteId($cartId);
 
-        $this->cartRepository->save($quote->reserveOrderId());
         if ($this->checkoutValidator !== null) {
             $this->checkoutValidator->validate($quote);
         }
@@ -52,7 +51,6 @@ class CheckoutManagement implements \Afterpay\Afterpay\Api\CheckoutManagementInt
         /** @var \Magento\Quote\Model\Quote $quote */
         $quote = $this->getActiveQuoteByCartOrQuoteId($cartId);
 
-        $this->cartRepository->save($quote->reserveOrderId());
         if ($this->expressCheckoutValidator !== null) {
             $this->expressCheckoutValidator->validate($quote);
         }


### PR DESCRIPTION
**Issue with the Save Function**
When I place an order with Afterpay, it does not capture the tax amount.

During order placement, when the create function is called and the save function is executed, it saves the reserve_order_id from the quote. Before the save function executes, we are collecting the totals correctly. However, after the save function executes, the quote_address table is updated, setting the tax amount to 0.0.

**Fix for the Issue**
I have removed the save function from the create and createExpress functions because it may not be required In AP. Because magento handles this using the core module:
In the core module: (https://github.com/magento/magento2/blob/203c2f78b1afa694a92fc3a5b601ffa54e55305a/app/code/Magento/Quote/Model/Quote.php#L2273)
Called from here while submitting the quote: https://github.com/magento/magento2/blob/203c2f78b1afa694a92fc3a5b601ffa54e55305a/app/code/Magento/Quote/Model/QuoteManagement.php#L556 

Now we can capture the tax amount with this fix 
